### PR TITLE
Fix tempfile invocation

### DIFF
--- a/lint4jsondb.py
+++ b/lint4jsondb.py
@@ -317,7 +317,7 @@ class ExecuteLintForEachFile:
 
 class ExecuteLintForAllFilesInOneInvocation:
     def __init__(self):
-        self._tmp_file = tempfile.TemporaryFile(delete=False, suffix='.lnt')
+        self._tmp_file = tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.lnt')
         self._last_invocation = None
 
     def _create_temporary_lint_config(self, json_db):


### PR DESCRIPTION
`tempfile` only accepts the `delete` argument for [`NamedTemporaryFile`](https://docs.python.org/3/library/tempfile.html). We should also open it in text mode or otherwise Python 3 will require byte strings to be provided to `write()` instead of the current normal strings