### PR TITLE
Normalize relative paths in compile_commands.json

### DIFF
--- a/lint4jsondb.py
+++ b/lint4jsondb.py
@@ -326,6 +326,8 @@ class ExecuteLintForAllFilesInOneInvocation:
                 f.write("-%s%s\n" % (prefix, define))
 
         def write_item():
+            item.file = os.path.normpath(
+                os.path.join(item.directory, item.file))
             f.write("\n\n// for: %s \n" % item.file)
             f.write("-save\n")
 
@@ -334,6 +336,8 @@ class ExecuteLintForAllFilesInOneInvocation:
             for include in item.invocation.includes:
                 if include not in includes:
                     includes.append(include)
+                    include = os.path.normpath(
+                        os.path.join(item.directory, include))
                     f.write("-i\"%s\"\n" % include)
 
             write_defines('d')

--- a/lint4jsondb.py
+++ b/lint4jsondb.py
@@ -183,6 +183,12 @@ class JsonDbEntry:
 
                 continue
 
+        # apply the directory to relative paths if needed
+        self.file = os.path.normpath(os.path.join(self.directory, self.file))
+        self.invocation.includes = [
+            os.path.normpath(os.path.join(self.directory, inc))
+            for inc in self.invocation.includes]
+
 
 class Lint4JsonCompilationDb:
     def __init__(self, compilation_db, include_only=set(), exclude_all=set()):
@@ -317,7 +323,8 @@ class ExecuteLintForEachFile:
 
 class ExecuteLintForAllFilesInOneInvocation:
     def __init__(self):
-        self._tmp_file = tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.lnt')
+        self._tmp_file = tempfile.NamedTemporaryFile(
+            mode='w+', delete=False, suffix='.lnt')
         self._last_invocation = None
 
     def _create_temporary_lint_config(self, json_db):
@@ -326,8 +333,6 @@ class ExecuteLintForAllFilesInOneInvocation:
                 f.write("-%s%s\n" % (prefix, define))
 
         def write_item():
-            item.file = os.path.normpath(
-                os.path.join(item.directory, item.file))
             f.write("\n\n// for: %s \n" % item.file)
             f.write("-save\n")
 
@@ -336,8 +341,6 @@ class ExecuteLintForAllFilesInOneInvocation:
             for include in item.invocation.includes:
                 if include not in includes:
                     includes.append(include)
-                    include = os.path.normpath(
-                        os.path.join(item.directory, include))
                     f.write("-i\"%s\"\n" % include)
 
             write_defines('d')

--- a/test_lint4jsondb.py
+++ b/test_lint4jsondb.py
@@ -19,7 +19,7 @@ class Lint4JsonCompilationDbUnitTest(unittest.TestCase):
             os.remove(self._json_tested)
 
     def __create_temp_json(self, content):
-        with tempfile.TemporaryFile('wb', delete=False) as f:
+        with tempfile.NamedTemporaryFile('wb', delete=False) as f:
             self._json_tested = f.name
             f.write(content)
 
@@ -264,7 +264,8 @@ class LintExecutorUnitTest(unittest.TestCase):
                               'stderr': -2, 'stdout': -1})
 
         # ensure lint is called
-        self.assertEqual(args.pop(0), os.path.join("<lint-path>", "<lint-exe>"))
+        self.assertEqual(args.pop(0), os.path.join(
+            "<lint-path>", "<lint-exe>"))
         # ensure lint suppresses the banner line
         self.assertEqual(args.pop(0), '-b')
         # ensure lint's "lnt" directory was added
@@ -280,3 +281,7 @@ class LintExecutorUnitTest(unittest.TestCase):
         self.assertEqual(args.pop(0), '-i"i2"')
         # ensure that the file to check is passed finally
         self.assertEqual(args.pop(0), "<file>")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Oftentimes the script location is different to `compile_commands.json` and relative paths don't make sense once the `.lnt` file has been generated. We can get around this by normalizing the paths as part of processing. 

However, this does break the current unit tests. Specifically, since `os.path` is platform dependent it only works if the paths match the executing platform, so we can't easily satisfy unit tests for both Windows and Linux path styles. What do you think we should do?